### PR TITLE
apply \hangindent\parindent to all fn paragraphs

### DIFF
--- a/uwthesis.cls
+++ b/uwthesis.cls
@@ -27,6 +27,7 @@
 %
 % Version history
 %
+% 9.03,05/21/19, use \everypar in \@makefntext
 % 9.02,11/22/16, minor changes to style to more closely follow grad school guidelines ( something else )
 % 9.01,03/03/15, rename singlespace to uwsinglespace so no collision with setspace style
 % 9.00,11/13/14, modify for proquest style.  Adjust sample thesis appropriately

--- a/uwthesis.cls
+++ b/uwthesis.cls
@@ -291,6 +291,7 @@
  \hrule width \columnwidth \kern 2.6\p@}
 \long\def\@makefntext#1{\parindent 1em\noindent \hangindent\parindent
  \uwsinglespace
+ \everypar{\hb@xt@1em{\hss} \hangindent\parindent}
  \hb@xt@1.8em{\hss\@makefnmark}#1}
  
 %


### PR DESCRIPTION
Multi-paragraph footnotes only had the \hangindent\parindent applied to
the first paragraph.  This uses everypar to get that formatting
throughout the footnote.