### PR TITLE
removed uwsinglespace from Degreetext and Programtext

### DIFF
--- a/uwthesis.cls
+++ b/uwthesis.cls
@@ -682,8 +682,7 @@
       \par\vskip\z@ plus4fill\relax
       \@Author
       \par\vskip\z@ plus4fill\relax
-      {\uwsinglespace
-      \@Degreetext\par}
+      \@Degreetext
       \par\vskip\z@ plus2fill\relax
       \@Degree
       \par\vskip\z@ plus2fill\relax
@@ -706,8 +705,9 @@
         \advance\count1 by1}
 
       \par\vskip\z@ plus4fill\relax
-       {\uwsinglespace
-      \@Programtext \par \@Program\par}
+      \@Programtext
+      \par\vskip\z@ plus1fill\relax
+      \@Program\par
       \par\vskip\z@ plus1fill\relax
     \end{center}
      \vspace{2pc}\relax


### PR DESCRIPTION
I am following the [sample thesis title](https://grad.uw.edu/wp-content/uploads/2019/06/sample-thesis-title.pdf) which appears to have been uploaded June 2019. It has double spacing for the Degreetext and Programtext.

Thanks for maintaining this package!