### PR TITLE
add page clear at start of copyrightpage

### DIFF
--- a/uwthesis.cls
+++ b/uwthesis.cls
@@ -662,6 +662,7 @@
 
  
 \def\copyrightpage{                   % Prints the copyright page
+    \cleardoublepage
     \vspace{7pc}
     \begin{center}
       \par\vskip\z@ plus4fill\relax


### PR DESCRIPTION
The [ETD Formatting Guidelines](https://grad.uw.edu/for-students-and-post-docs/thesisdissertation/etd-formatting-guidelines/) specify that the copyrightpage can be the first or second page. If it is the second page, it currently wraps onto the the titlepage. This adds a clear, placing it on its own.