### PR TITLE
Allows selection of the openright option

### DIFF
--- a/uwthesis.cls
+++ b/uwthesis.cls
@@ -129,8 +129,19 @@
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{book}}
 
 \PassOptionsToClass{\@f@ntsize}{book}
-\PassOptionsToClass{openany}{book}
+
+\newif\if@openrightselected % true if openright is selected
+  \@openrightselectedfalse
+\DeclareOption{openright}{\@openrightselectedtrue}
+
 \ProcessOptions
+
+\if@openrightselected % default to openany
+  \PassOptionsToClass{openright}{book}
+\else
+  \PassOptionsToClass{openany}{book}
+\fi
+
 \LoadClass{book}
 
 \ifproquest


### PR DESCRIPTION
Currently the `uwthesis` class explicitly passes the `openany` option to the `book` class from which it is derived. While in many cases this is the desired option, it would be preferable for the `openright` option to be available when desired. This pull request modifies the `uwthesis` class to allow the `openright` option to be used while still defaulting to `openany`.